### PR TITLE
document timeseries v0.2.0 features

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -29,6 +29,7 @@
           "timeseries/quickstart",
           "timeseries/storage-design",
           "timeseries/configuration",
+          "timeseries/ingest",
           "timeseries/production",
           {
             "group": "API reference",

--- a/overview/architecture.mdx
+++ b/overview/architecture.mdx
@@ -71,6 +71,12 @@ from within the region they are produced and then transferred to the single
 writer over S3.  This both avoids the cross-zone data transfer costs and only
 depends on the availability of S3.
 
+<Note>
+  Timeseries implements this pattern for OpenTelemetry metrics via the
+  `opendata` OTel Collector exporter and an in-server ingest consumer. See
+  [Stateless Ingest](/timeseries/ingest) for the write path.
+</Note>
+
 <pre className="ascii-art">{`
 ┌─────────────────────────────────────────────────────────────────────┐
 │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ stateless zonal ingestion ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│

--- a/overview/writing-data.mdx
+++ b/overview/writing-data.mdx
@@ -79,6 +79,12 @@ Since WAL files are flushed frequently on a configurable interval, the
 buffered mode still provides durability within a bounded time window. Choosing
 the right level depends on the use case.
 
+A third option decouples durability from the writer entirely: clients can
+write into an object-storage queue, and the main writer drains that queue
+asynchronously. The write returns as soon as the batch is durable in object
+storage, so ingest keeps working across writer restarts or failovers. See
+[Stateless Ingest](/timeseries/ingest) for the Timeseries implementation.
+
 ### Backpressure & Flow Control
 
 When writes arrive faster than Deltas can be flushed to object storage, the

--- a/timeseries/configuration.mdx
+++ b/timeseries/configuration.mdx
@@ -47,6 +47,12 @@ storage:
 
 # How often (in seconds) to flush data from memory to durable storage.
 [ flush_interval_secs: <int> | default = 5 ]
+
+# Startup cache warmer (enabled by default).
+[ cache_warmer: <cache_warmer_config> ]
+
+# Durable ingest consumer. See the Stateless Ingest page for the full write path.
+[ ingest_consumer: <ingest_consumer_config> ]
 ```
 
 ### `<scrape_config>`
@@ -113,12 +119,53 @@ type: <string> # One of: InMemory, SlateDb
       # in the working directory and merges any SLATEDB_-prefixed environment variables.
       [ settings_path: <string> ]
 
+      # Block cache (optional). See <block_cache_config> below.
+      [ block_cache: <block_cache_config> ]
+
       # Object store provider configuration (required).
       object_store:
         <object_store_config>
     ```
   </Tab>
 </Tabs>
+
+### `<block_cache_config>`
+
+The block cache sits in front of SlateDB and holds decoded SST blocks. It is
+tagged by `type`. Only `FoyerHybrid` is currently available.
+
+```yaml
+block_cache:
+  type: FoyerHybrid
+
+  # In-memory tier capacity in bytes.
+  memory_capacity: <int>
+
+  # On-disk tier capacity in bytes.
+  disk_capacity: <int>
+
+  # Directory for the on-disk tier.
+  disk_path: <string>
+
+  # When entries are promoted to the disk tier.
+  # WriteOnInsertion persists every cached block; WriteOnEviction
+  # only persists on memory eviction.
+  [ write_policy: <string> | default = WriteOnInsertion ]
+
+  # Flush thread count for the disk engine.
+  [ flushers: <int> | default = 4 ]
+
+  # Flush-pipeline buffer pool size in bytes. Actual allocation is ~2x
+  # this value (flushers double-buffer). Defaults to memory_capacity / 32.
+  [ buffer_pool_size: <int> ]
+
+  # Write-queue size threshold in bytes. Entries beyond this are dropped
+  # rather than blocking the cache.
+  [ submit_queue_size_threshold: <int> | default = 1073741824 ]
+```
+
+See the [production guide](/timeseries/production#block-cache) for recommended
+sizes.
 
 ### `<object_store_config>`
 
@@ -150,6 +197,49 @@ The object store is tagged by `type`.
     ```
   </Tab>
 </Tabs>
+
+### `<cache_warmer_config>`
+
+On startup, the server scans recent time bucket key ranges through the storage
+reader. The block cache picks up those blocks as a side effect, so the first
+queries after a restart do not pay cold-cache latency. The warmer runs once
+and exits.
+
+Enabled by default. Set `cache_warmer: null` to disable.
+
+```yaml
+cache_warmer:
+  # How far back to scan on startup.
+  [ warm_range: <duration> | default = 24h ]
+
+  # Whether to warm raw sample data in addition to index metadata.
+  [ include_samples: <bool> | default = true ]
+```
+
+Disable the warmer when starting read-only replicas that only serve recent
+queries, where the up-front scan cost outweighs the benefit.
+
+### `<ingest_consumer_config>`
+
+Enables the durable-queue write path. See the
+[Stateless Ingest page](/timeseries/ingest) for the full architecture, the
+OpenTelemetry Collector side, and operational guidance.
+
+```yaml
+ingest_consumer:
+  # Object store holding the ingest queue. May differ from the TSDB's
+  # storage bucket.
+  object_store:
+    <object_store_config>
+
+  # Must match the manifest path configured on the producer side.
+  [ manifest_path: <string> | default = "ingest/manifest" ]
+
+  # Delay between polls when the queue is empty.
+  [ poll_interval: <duration> | default = 1s ]
+```
+
+Requires read-write mode. When absent, no consumer starts.
 
 ## Examples
 

--- a/timeseries/ingest.mdx
+++ b/timeseries/ingest.mdx
@@ -1,0 +1,233 @@
+---
+title: Stateless Ingest
+description: Durable OTLP ingest for Timeseries via an object-storage queue
+---
+
+Timeseries can accept OpenTelemetry metrics through a durable queue in object
+storage instead of (or in addition to) the direct OTLP/HTTP endpoint. An
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) with the
+`opendata` exporter writes batches into the queue, and a background consumer
+inside the Timeseries server drains them into the TSDB.
+
+This is the [stateless zonal ingestion](/overview/architecture#stateless-zonal-ingestion)
+pattern applied to metrics.
+
+## Why use it
+
+The direct OTLP/HTTP endpoint couples ingest availability to TSDB availability.
+If the server is down or crashes before it has flushed an accepted request, the
+metrics are lost. Routing writes through object storage changes that:
+
+- Producers keep writing even when the TSDB is unavailable.
+- A crashed consumer resumes from the last acked batch.
+- Traffic stays within the AZ, avoiding cross-zone transfer fees that add up
+  at high metric volumes.
+
+The tradeoff is end-to-end latency: a metric is not queryable until the
+collector flushes its batch and the consumer reads, decodes, and writes it. For
+monitoring workloads this is acceptable; for sub-second freshness, use the
+direct OTLP/HTTP endpoint.
+
+## Architecture
+
+```
+    ┌────────────────┐
+    │ OTel SDK / App │
+    └────────┬───────┘
+             │
+    ╔════════▼══════════════╗
+    ║ OTel Collector        ║
+    ║                       ║         ┌────────────────────┐
+    ║ ┌───────────────────┐ ║         │   Object Storage   │
+    ║ │     Receiver      │ ║   ┌─────▶ (data + manifest)  │
+    ║ └───────────────────┘ ║   │     │                    │
+    ║                       ║   │     └──────────┬─────────┘
+    ║ ┌───────────────────┐ ║   │                │
+    ║ │ opendata exporter ├─╫───┘                │
+    ║ └───────────────────┘ ║                    │
+    ╚═══════════════════════╝                    │
+                                                 │
+                             ╔═══════════════════▼═════════════╗
+                             ║ Timeseries Server               ║
+                             ║                                 ║
+                             ║ ┌─────────────────────────────┐ ║
+                             ║ │ IngestConsumer              │ ║
+                             ║ │   poll manifest             │ ║
+                             ║ │   decode OTLP protobuf      │ ║
+                             ║ │   convert + write to TSDB   │ ║
+                             ║ └─────────────────────────────┘ ║
+                             ╚═════════════════════════════════╝
+```
+
+Both paths converge on the same OTLP-to-Prometheus conversion and TSDB write,
+so semantics match exactly. You can run both at once if some pipelines need
+immediate writes and others tolerate queue latency.
+
+## Collector side
+
+The `opendata` exporter lives in the
+[`opendata-go`](https://github.com/opendata-oss/opendata-go) repository and is
+distributed as a standalone OTel Collector component. Build a custom collector
+with the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
+
+### Builder config
+
+```yaml builder-config.yaml
+dist:
+  name: opendata-otelcol
+  description: OpenTelemetry Collector with OpenData exporter support
+  output_path: ./_build
+  otelcol_version: 0.149.0
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.149.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.149.0
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.149.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.149.0
+  - gomod: github.com/opendata-oss/opendata-go/exporter/opendataexporter v0.2.0
+```
+
+Build and run:
+
+```bash
+go install go.opentelemetry.io/collector/cmd/builder@v0.149.0
+builder --config builder-config.yaml
+./_build/opendata-otelcol --config collector-config.yaml
+```
+
+Or build a container image from the same builder config:
+
+```dockerfile Dockerfile
+FROM golang:1.26.1 AS builder
+ARG OCB_VERSION=0.149.0
+WORKDIR /src
+RUN go install go.opentelemetry.io/collector/cmd/builder@v${OCB_VERSION}
+COPY builder-config.yaml /src/builder-config.yaml
+RUN builder --config /src/builder-config.yaml
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=builder /src/_build/opendata-otelcol /otelcol-custom
+ENTRYPOINT ["/otelcol-custom"]
+```
+
+### Exporter config
+
+```yaml collector-config.yaml
+exporters:
+  opendata:
+    object_store:
+      type: s3
+      bucket: my-ingest-bucket
+      region: us-west-2
+    data_path_prefix: ingest/otel/metrics/data
+    manifest_path: ingest/otel/metrics/manifest
+    flush_interval: 10s
+    flush_size_bytes: 1048576
+    compression: zstd
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [opendata]
+```
+
+| Field | Description |
+| --- | --- |
+| `object_store` | Bucket where batches and the manifest are written. Must match the consumer's `object_store`. |
+| `data_path_prefix` | Path prefix for batch objects. |
+| `manifest_path` | Path to the queue manifest. The consumer reads the same path. |
+| `flush_interval` | Maximum time a batch is held before flushing. |
+| `flush_size_bytes` | Size threshold that triggers a flush. |
+| `compression` | `none` or `zstd`. Zstd uses level 3. |
+
+Each `ConsumeMetrics` call marshals the OTLP protobuf, writes it as one entry
+with a 4-byte metadata header identifying it as metrics, and awaits durable
+confirmation from object storage before returning to the pipeline. That means a
+batch processor upstream is the right place to trade off request rate against
+flush rate.
+
+## Consumer side
+
+Turn on the consumer by adding `ingest_consumer` to `prometheus.yaml`:
+
+```yaml prometheus.yaml
+ingest_consumer:
+  object_store:
+    type: S3
+    region: us-west-2
+    bucket: my-ingest-bucket
+  manifest_path: ingest/otel/metrics/manifest
+  poll_interval: 1s
+```
+
+The consumer runs as a background task inside the Timeseries server. It
+requires read-write mode and only starts when this section is present. The
+object store does not have to be the same bucket the TSDB uses; the queue is a
+separate buffer.
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `object_store` | required | Bucket holding the queue. |
+| `manifest_path` | `ingest/manifest` | Must match the exporter's `manifest_path`. |
+| `poll_interval` | `1s` | Delay between polls when the queue is empty. |
+
+On startup the consumer fences any previous consumer via the manifest's
+epoch-based compare-and-set, then begins polling. On shutdown it flushes
+pending acks before releasing the object store.
+
+## Batch format
+
+Batches are self-describing. Each file contains a record block (optionally
+compressed) followed by a 7-byte footer that indicates the compression type,
+record count, and format version. The consumer reads the footer, decompresses
+the record block if needed, and parses the length-prefixed entries.
+
+See [RFC 0001](https://github.com/opendata-oss/opendata/blob/main/ingest/rfcs/0001-stateless-ingest.md)
+for the wire format and
+[RFC 0006](https://github.com/opendata-oss/opendata/blob/main/timeseries/rfcs/0006-ingest-consumer.md)
+for the 4-byte metadata header that tells the consumer a batch holds OTLP
+metrics.
+
+## Delivery semantics
+
+At-least-once. If the consumer crashes between processing a batch and acking
+it, the batch is re-read on restart. Duplicate writes to the TSDB are
+idempotent: samples are keyed by `(series, timestamp)`, so a replay overwrites
+with the same value.
+
+## Observability
+
+The consumer publishes metrics under the `opendata_ingest_consumer_` prefix on
+the Timeseries `/metrics` endpoint.
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `..._batches_processed_total` | counter | Batches drained from the queue. |
+| `..._entries_processed_total` | counter | OTLP entries decoded successfully. |
+| `..._entries_skipped_total` | counter | Entries skipped due to decode or conversion errors. |
+| `..._series_ingested_total` | counter | Series written to the TSDB. |
+| `..._batch_processing_duration_seconds` | histogram | Per-batch processing latency. |
+| `..._poll_empty_total` | counter | Polls that returned no work. |
+
+A queue that is growing without `batches_processed_total` keeping up means the
+consumer is falling behind. Check TSDB write latency and consider reducing
+`flush_interval` on the exporter side (smaller, more frequent batches reduce
+per-batch variance) or raising the consumer's CPU budget.
+
+## Running both paths
+
+`ingest_consumer` and the OTLP/HTTP endpoint coexist. A common setup is:
+
+- Route high-volume, lossy-tolerant OTel traffic through the queue.
+- Keep the direct endpoint for low-latency writes (scrapers, remote-write
+  senders, local agents).
+
+Both paths use the same converter and write through `TimeSeriesDb::write`, so
+there is no semantic difference between a metric that arrived via the queue
+and one that arrived over HTTP.

--- a/timeseries/production.mdx
+++ b/timeseries/production.mdx
@@ -43,7 +43,7 @@ these files under `charts/opendata-timeseries/`.
 ```yaml values.yaml
 image:
   repository: ghcr.io/opendata-oss/timeseries
-  tag: "0.1.8"
+  tag: "0.2.0"
 
 port: 9090
 
@@ -282,6 +282,57 @@ from S3. For production workloads, use an SSD-backed StorageClass:
   Avoid using HDD-backed volumes (e.g. `st1`, `sc1`) for the cache. SlateDB
   issues many small random reads, and spinning disks will bottleneck performance.
 </Warning>
+
+### Block cache
+
+On top of SlateDB's disk cache, Timeseries can keep decoded blocks in a
+hybrid memory-plus-disk block cache backed by [foyer](https://foyer.rs). Add
+it under `storage` in `prometheus.yaml`:
+
+```yaml prometheus.yaml
+storage:
+  type: SlateDb
+  path: timeseries
+  object_store:
+    type: Aws
+    region: us-west-2
+    bucket: my-timeseries-bucket
+  block_cache:
+    type: FoyerHybrid
+    memory_capacity: 8589934592    # 8 GiB
+    disk_capacity: 107374182400    # 100 GiB
+    disk_path: /cache/foyer
+    write_policy: WriteOnInsertion
+    flushers: 4
+```
+
+Sizing guidance:
+
+- Set `memory_capacity` to roughly the recent working set (the last few hours
+  of bucket index and sample data).
+- Point `disk_path` at the same SSD-backed PVC used by the disk cache; the
+  two workloads coexist.
+- Keep `write_policy: WriteOnInsertion` so every cached block is also on disk.
+  Restarts then hit the disk tier instead of re-reading from S3.
+- Raise `flushers` if the `foyer_*` write-queue metrics show backpressure.
+
+See [`<block_cache_config>`](/timeseries/configuration#block_cache_config) for
+the full field reference.
+
+### Cache warmer
+
+On startup the server scans recent time bucket key ranges through the storage
+reader, which populates the block cache. Queries that hit in the first few
+seconds after a restart avoid a cold-cache penalty. This is on by default and
+covers the last 24 hours including sample data. To tune or disable it, see
+[`<cache_warmer_config>`](/timeseries/configuration#cache_warmer_config).
+
+### Durable OTLP ingest
+
+For high-volume OTel metrics, run the [stateless ingest](/timeseries/ingest)
+path instead of (or alongside) direct OTLP/HTTP writes. Producers keep writing
+during TSDB restarts, writes stay inside the AZ, and a crashed consumer
+resumes from the last acked batch on its own.
 
 ### Health checks
 


### PR DESCRIPTION
- new Stateless Ingest page covering the opendata OTel Collector exporter, the in-server ingest consumer, and the end-to-end write path
- configuration reference for cache_warmer, ingest_consumer, and the FoyerHybrid block_cache options
- production guide sections on the block cache, cache warmer, and durable OTLP ingest
- cross-references from the architecture and writing-data overviews
- Helm chart image tag bumped to 0.2.0