### PR TITLE
docs(buffer): document the read-ahead and ack_through API (RFC 0003)

### DIFF
--- a/buffer/architecture.mdx
+++ b/buffer/architecture.mdx
@@ -156,6 +156,147 @@ with that last persisted sequence number so it resumes right after it. The
 new consumer also bumps the epoch, fencing the old one and preventing any
 duplicate writes.
 
+## Read-ahead and batched acks
+
+The serial `next_batch` / `ack` API caps a consumer at one manifest read
+and one ack write per batch. Fetching a batch is an I/O wait; decoding it
+is CPU work; doing both on one task in a tight loop wastes both the
+object-store bandwidth and the machine's cores. For high-throughput
+consumers, `Consumer` exposes a parallel-fetch path:
+
+```rust
+pub async fn next_descriptors(&mut self, max: usize)
+    -> Result<Vec<BatchDescriptor>>;
+pub async fn fetch_descriptor(&mut self, d: BatchDescriptor)
+    -> Result<ConsumedBatch>;
+pub fn fetch_handle(&self) -> ConsumerFetchHandle;
+pub async fn ack_through(&mut self, sequence: u64) -> Result<()>;
+```
+
+The design batches the expensive low-volume operations (manifest read,
+ack) and parallelizes the cheap-per-call high-volume operations (fetch,
+decode). The legacy `next_batch` / `ack` API still works without changes:
+`next_batch` is a thin wrapper over `next_descriptors(1)` plus
+`fetch_descriptor`, and `ack` keeps its amortize-every-100 behavior.
+
+### How the split works
+
+`next_descriptors(max)` reads the manifest once and returns up to `max`
+contiguous descriptors past an internal read-ahead cursor. It does no
+object-store fetch and does not mutate the durable ack frontier.
+
+`ConsumerFetchHandle` is a cheap, cloneable handle obtained from
+`fetch_handle()`. It holds an `Arc` to the object store and the manifest
+path. Its single method, `fetch(&self, descriptor) -> Result<ConsumedBatch>`,
+fetches and decodes one batch, touches no `Consumer` cursor, and is safe
+to call concurrently from many tasks. Cloning the handle is O(1).
+
+`ack_through(sequence)` advances the durable ack frontier through
+`sequence` in one `dequeue` write, no matter how far the frontier moves.
+The dequeue runs first; in-memory state and the `buffer.acks` counter
+advance only on success, so a fence or storage error leaves the
+consumer's state untouched and the call is safe to retry.
+
+### Pipelined consumer pattern
+
+One task owns the `Consumer` and the manifest; N fetch workers each hold
+a clone of the handle and pull descriptors off a bounded channel:
+
+```rust
+let consumer = Consumer::new(config, last_acked).await?;
+let fetcher  = consumer.fetch_handle();
+
+// N fetch workers, each holding a clone of the handle:
+for _ in 0..fetch_concurrency {
+    let f = fetcher.clone();
+    let rx = descriptor_rx.clone();
+    tokio::spawn(async move {
+        while let Some(d) = rx.recv().await {
+            let batch = f.fetch(d).await?;
+            // ...hand off to a decode / sink stage...
+        }
+        Ok::<(), Error>(())
+    });
+}
+
+// Owner task: pull a run of descriptors, fan them out, ack the
+// contiguous high watermark.
+loop {
+    let descriptors = consumer.next_descriptors(K).await?;
+    for d in descriptors { descriptor_tx.send(d).await?; }
+    // ...wait for the contiguous-completed high watermark, then:
+    consumer.ack_through(high).await?;
+}
+```
+
+Owner and workers run in parallel because their state is disjoint: the
+owner's `&mut Consumer` and the workers' `&self` on cloned handles do
+not interact at the borrow-checker level. Two concurrent fetches against
+distinct descriptors do not contend on the manifest.
+
+### Descriptor handout contract
+
+`next_descriptors` advances an internal `last_handed_out_sequence`
+*before* the caller has fetched the objects. Read-ahead is the point.
+That places one obligation on the caller:
+
+`ack_through(n)` does not verify that anything below `n` was processed.
+It unconditionally advances the durable frontier to `n`, rejecting only
+`n <= last_acked_sequence`. The caller must track which sequences have
+actually been processed and only call `ack_through` with the highest
+fully-processed *contiguous* sequence. Fetches may complete out of order;
+ack the contiguous-complete watermark, never past a still-pending
+sequence.
+
+If a descriptor is permanently lost (a worker panics, a channel send is
+dropped), the frontier stalls at that sequence. Recovery is process
+restart: `Consumer::new(config, last_acked_sequence)` re-emits everything
+the durable frontier has not acked.
+
+### Fencing
+
+`next_descriptors` returns `Error::Fenced` on the next manifest read
+after fencing. A worker holding a stale handle keeps fetching
+successfully against object storage; the manifest owner learns of the
+fence and propagates it, typically by closing the descriptor channel.
+`ack_through` against a fenced manifest returns `Error::Fenced` and
+leaves state untouched, so a fenced consumer cannot advance the durable
+frontier.
+
+### Cursor semantics
+
+The consumer maintains three monotonic cursors, all on `Consumer` and
+all mutated only through `&mut self`:
+
+| Cursor | Advances on | Meaning |
+|---|---|---|
+| `last_acked_sequence` | `ack` success, `ack_through` after a successful dequeue | Highest sequence durably dequeued |
+| `last_fetched_sequence` | `fetch_descriptor` | Highest sequence the serial wrapper has read; feeds `consumer_lag_seconds` |
+| `last_handed_out_sequence` | `next_descriptors` | Highest sequence handed out as a descriptor |
+
+`ConsumerFetchHandle::fetch` advances no cursor. A parallel-fetch caller
+that wants a lag signal computes it from
+`ConsumedBatch.metadata.last().ingestion_time_ms` against wall-clock
+time and emits its own gauge.
+
+### When to use which API
+
+The serial `next_batch` / `ack` API stays the right choice for
+low-throughput single-task consumers (the timeseries and vector buffer
+consumers use it) and for backfill tooling where a tight per-batch ack
+loop is simpler than the pipeline.
+
+Reach for the read-ahead path when consumer throughput is bounded by
+manifest round-trips (one `next_batch` cycle per batch caps throughput
+at `1 / manifest_RTT`), when fetch I/O and decode CPU need to overlap
+across batches, or when the workload is bursty enough that an in-flight
+bytes ceiling fits better than per-batch flow control.
+
+The opendata-contrib generic ingest runtime is one pipelined consumer
+built on these primitives. Full design rationale, the descriptor handout
+contract in detail, and the failure-mode catalog live in [RFC 0003:
+Consumer Read-Ahead and `ack_through`](https://github.com/opendata-oss/opendata/blob/main/buffer/rfcs/0003-consumer-read-ahead.md).
+
 ## Usage example
 
 For an example of how Buffer can be integrated into an ingestion pipeline see

--- a/buffer/architecture.mdx
+++ b/buffer/architecture.mdx
@@ -160,7 +160,8 @@ duplicate writes.
 
 The serial `next_batch` / `ack` API caps a consumer at one manifest read
 and one ack write per batch. Fetching a batch is an I/O wait; decoding it
-is CPU work; doing both on one task in a tight loop wastes both the
+is CPU work; and writing it to another system is yet more I/O work. Doing 
+everything on one task in a tight loop wastes both the
 object-store bandwidth and the machine's cores. For high-throughput
 consumers, `Consumer` exposes a parallel-fetch path:
 
@@ -174,10 +175,10 @@ pub async fn ack_through(&mut self, sequence: u64) -> Result<()>;
 ```
 
 The design batches the expensive low-volume operations (manifest read,
-ack) and parallelizes the cheap-per-call high-volume operations (fetch,
-decode). The legacy `next_batch` / `ack` API still works without changes:
+ack) and parallelizes the high-volume operations (fetch,
+decode). The serial `next_batch` / `ack` API still works without changes:
 `next_batch` is a thin wrapper over `next_descriptors(1)` plus
-`fetch_descriptor`, and `ack` keeps its amortize-every-100 behavior.
+`fetch_descriptor`, and `ack` keeps its amortize-every-100-calls behavior.
 
 ### How the split works
 
@@ -229,10 +230,8 @@ loop {
 }
 ```
 
-Owner and workers run in parallel because their state is disjoint: the
-owner's `&mut Consumer` and the workers' `&self` on cloned handles do
-not interact at the borrow-checker level. Two concurrent fetches against
-distinct descriptors do not contend on the manifest.
+Owner and workers run in parallel because their state is disjoint: two 
+concurrent fetches against distinct descriptors do not contend on the manifest.
 
 ### Descriptor handout contract
 
@@ -263,22 +262,6 @@ fence and propagates it, typically by closing the descriptor channel.
 leaves state untouched, so a fenced consumer cannot advance the durable
 frontier.
 
-### Cursor semantics
-
-The consumer maintains three monotonic cursors, all on `Consumer` and
-all mutated only through `&mut self`:
-
-| Cursor | Advances on | Meaning |
-|---|---|---|
-| `last_acked_sequence` | `ack` success, `ack_through` after a successful dequeue | Highest sequence durably dequeued |
-| `last_fetched_sequence` | `fetch_descriptor` | Highest sequence the serial wrapper has read; feeds `consumer_lag_seconds` |
-| `last_handed_out_sequence` | `next_descriptors` | Highest sequence handed out as a descriptor |
-
-`ConsumerFetchHandle::fetch` advances no cursor. A parallel-fetch caller
-that wants a lag signal computes it from
-`ConsumedBatch.metadata.last().ingestion_time_ms` against wall-clock
-time and emits its own gauge.
-
 ### When to use which API
 
 The serial `next_batch` / `ack` API stays the right choice for
@@ -292,7 +275,7 @@ at `1 / manifest_RTT`), when fetch I/O and decode CPU need to overlap
 across batches, or when the workload is bursty enough that an in-flight
 bytes ceiling fits better than per-batch flow control.
 
-The opendata-contrib generic ingest runtime is one pipelined consumer
+The opendata-contrib [generic ingest runtime](https://github.com/opendata-oss/opendata-contrib/blob/main/rfcs/0002-generic-ingest-runtime.md) is one pipelined consumer
 built on these primitives. Full design rationale, the descriptor handout
 contract in detail, and the failure-mode catalog live in [RFC 0003:
 Consumer Read-Ahead and `ack_through`](https://github.com/opendata-oss/opendata/blob/main/buffer/rfcs/0003-consumer-read-ahead.md).


### PR DESCRIPTION
## Summary

- Adds a **Read-ahead and batched acks** section to `docs/buffer/architecture.mdx`
- Documents the new public surface on `Consumer`: `next_descriptors`, `fetch_handle`, `fetch_descriptor`, `ack_through`, plus the cloneable `ConsumerFetchHandle`
- Covers the manifest/fetch split, the pipelined consumer pattern (one owner task + N cloned fetch handles), the descriptor handout contract the caller must honor, fencing semantics, and the three monotonic cursors
- Notes when to choose the read-ahead path over the serial `next_batch` / `ack` API
- Links back to RFC 0003 in the opendata repo for full design

Companion to the launch of `opendata-buffer 0.3.0` and the pipelined ClickHouse ingestor.

## Test plan

- [ ] Render locally and confirm the new section flows after Consumer and before Usage example
- [ ] Check the GitHub link to RFC 0003 resolves
- [ ] Confirm no formatting issues in the markdown table

🤖 Generated with [Claude Code](https://claude.com/claude-code)