### PR TITLE
Timeseries: document meta_cache and the SlateDB-based cache warmer

### DIFF
--- a/timeseries/configuration.mdx
+++ b/timeseries/configuration.mdx
@@ -269,7 +269,8 @@ cache_warmer:
 ```
 
 Match `warm_range` to the time range your dashboards and alerts query most.
-Warming more than the caches can hold evicts the oldest warmed blocks first.
+A warm window that exceeds cache capacity wastes work: some warmed blocks
+are evicted again before a query ever reads them.
 
 ### `<buffer_consumer_config>`
 

--- a/timeseries/configuration.mdx
+++ b/timeseries/configuration.mdx
@@ -120,8 +120,12 @@ type: <string> # One of: InMemory, SlateDb
       # in the working directory and merges any SLATEDB_-prefixed environment variables.
       [ settings_path: <string> ]
 
-      # Block cache (optional). See <block_cache_config> below.
-      [ block_cache: <block_cache_config> ]
+      # Cache for SST data blocks (optional). See <cache_config> below.
+      [ block_cache: <cache_config> ]
+
+      # Cache for SST metadata: filters, indexes, and stats blocks.
+      # Set this whenever block_cache is set. See <cache_config> below.
+      [ meta_cache: <cache_config> ]
 
       # Object store provider configuration (required).
       object_store:
@@ -130,43 +134,84 @@ type: <string> # One of: InMemory, SlateDb
   </Tab>
 </Tabs>
 
-### `<block_cache_config>`
+### `<cache_config>`
 
-The block cache sits in front of SlateDB and holds decoded SST blocks. It is
-tagged by `type`. Only `FoyerHybrid` is currently available.
+The same cache configuration is used for two slots: `block_cache` holds
+decoded SST data blocks, and `meta_cache` holds SST metadata — filters,
+indexes, and stats blocks. When either is set, SlateDB routes data blocks to
+`block_cache` and metadata blocks to `meta_cache`. A slot left unset caches
+nothing for that class of block.
 
-```yaml
-block_cache:
-  type: FoyerHybrid
+<Warning>
+  Setting `block_cache` without `meta_cache` leaves filters and indexes
+  uncached, so every read fetches them from the object store again. Because
+  each read consults the filter of every SST that might hold the key, query
+  latency then grows with SST count. Always pair `block_cache` with a
+  `meta_cache`.
+</Warning>
 
-  # In-memory tier capacity in bytes.
-  memory_capacity: <int>
+A cache is tagged by `type`: `FoyerHybrid` (memory + disk tiers) or
+`FoyerMemory` (memory only), both backed by [foyer](https://foyer.rs).
 
-  # On-disk tier capacity in bytes.
-  disk_capacity: <int>
+<Tabs>
+  <Tab title="FoyerHybrid">
+    Two tiers: in-memory plus on-disk (ideally NVMe). Suited to the
+    `block_cache` slot, where capacity matters more than the last few
+    microseconds of latency.
 
-  # Directory for the on-disk tier.
-  disk_path: <string>
+    ```yaml
+    block_cache:
+      type: FoyerHybrid
 
-  # When entries are promoted to the disk tier.
-  # WriteOnInsertion persists every cached block; WriteOnEviction
-  # only persists on memory eviction.
-  [ write_policy: <string> | default = WriteOnInsertion ]
+      # In-memory tier capacity in bytes.
+      memory_capacity: <int>
 
-  # Flush thread count for the disk engine.
-  [ flushers: <int> | default = 4 ]
+      # On-disk tier capacity in bytes.
+      disk_capacity: <int>
 
-  # Flush-pipeline buffer pool size in bytes. Actual allocation is ~2x
-  # this value (flushers double-buffer). Defaults to memory_capacity / 32.
-  [ buffer_pool_size: <int> ]
+      # Directory for the on-disk tier.
+      disk_path: <string>
 
-  # Write-queue size threshold in bytes. Entries beyond this are dropped
-  # rather than blocking the cache.
-  [ submit_queue_size_threshold: <int> | default = 1073741824 ]
-```
+      # When entries are promoted to the disk tier.
+      # WriteOnInsertion persists every cached block; WriteOnEviction
+      # only persists on memory eviction.
+      [ write_policy: <string> | default = WriteOnInsertion ]
 
-See the [production guide](/timeseries/production#block-cache) for recommended
-sizes.
+      # Flush thread count for the disk engine.
+      [ flushers: <int> | default = 4 ]
+
+      # Flush-pipeline buffer pool size in bytes. Actual allocation is ~2x
+      # this value (flushers double-buffer). Defaults to memory_capacity / 32.
+      [ buffer_pool_size: <int> ]
+
+      # Write-queue size threshold in bytes. Entries beyond this are dropped
+      # rather than blocking the cache.
+      [ submit_queue_size_threshold: <int> | default = 1073741824 ]
+    ```
+  </Tab>
+  <Tab title="FoyerMemory">
+    A single in-memory tier. Suited to the `meta_cache` slot: metadata blocks
+    are small but consulted on every read, so they belong in memory, and the
+    [cache warmer](#cache_warmer_config) rebuilds the cache cheaply after a
+    restart. Size it to hold the full live filter and index set so it never
+    evicts.
+
+    ```yaml
+    meta_cache:
+      type: FoyerMemory
+
+      # Cache capacity in bytes.
+      capacity: <int>
+
+      # Number of shards. When absent, foyer derives a default from the
+      # available CPU count.
+      [ shards: <int> ]
+    ```
+  </Tab>
+</Tabs>
+
+See the [production guide](/timeseries/production#block-and-metadata-caches)
+for recommended sizes.
 
 ### `<object_store_config>`
 
@@ -201,24 +246,30 @@ The object store is tagged by `type`.
 
 ### `<cache_warmer_config>`
 
-On startup, the server scans recent time bucket key ranges through the storage
-reader. The block cache picks up those blocks as a side effect, so the first
-queries after a restart do not pay cold-cache latency. The warmer runs once
-and exits.
+On startup, the warmer discovers the time buckets that overlap the warm window
+and hands the SSTs backing them to SlateDB's cache manager, which loads each
+SST's filters and index — and, when `include_samples` is set, its sample data
+blocks — directly into the configured caches. Filters and indexes land in
+`meta_cache`, data blocks in `block_cache`. The first queries after a restart
+then run against warm caches instead of paying object-store round trips.
+
+The warmer runs once and exits. It is a no-op when neither cache is
+configured. Pairing it with an in-memory `meta_cache` works well: the cache
+loses its contents on restart, and the warmer rebuilds them in seconds.
 
 Enabled by default. Set `cache_warmer: null` to disable.
 
 ```yaml
 cache_warmer:
-  # How far back to scan on startup.
+  # How far back to warm on startup.
   [ warm_range: <duration> | default = 24h ]
 
-  # Whether to warm raw sample data in addition to index metadata.
+  # Whether to warm sample data blocks in addition to filters and indexes.
   [ include_samples: <bool> | default = true ]
 ```
 
-Disable the warmer when starting read-only replicas that only serve recent
-queries, where the up-front scan cost outweighs the benefit.
+Match `warm_range` to the time range your dashboards and alerts query most.
+Warming more than the caches can hold evicts the oldest warmed blocks first.
 
 ### `<buffer_consumer_config>`
 

--- a/timeseries/configuration.mdx
+++ b/timeseries/configuration.mdx
@@ -136,11 +136,11 @@ type: <string> # One of: InMemory, SlateDb
 
 ### `<cache_config>`
 
-The same cache configuration is used for two slots: `block_cache` holds
-decoded SST data blocks, and `meta_cache` holds SST metadata — filters,
-indexes, and stats blocks. When either is set, SlateDB routes data blocks to
-`block_cache` and metadata blocks to `meta_cache`. A slot left unset caches
-nothing for that class of block.
+Two slots share this cache configuration: `block_cache` holds decoded SST
+data blocks, and `meta_cache` holds SST metadata (filters, indexes, and stats
+blocks). When either is set, SlateDB routes data blocks to `block_cache` and
+metadata blocks to `meta_cache`. A slot left unset caches nothing for that
+class of block.
 
 <Warning>
   Setting `block_cache` without `meta_cache` leaves filters and indexes
@@ -191,7 +191,7 @@ A cache is tagged by `type`: `FoyerHybrid` (memory + disk tiers) or
   </Tab>
   <Tab title="FoyerMemory">
     A single in-memory tier. Suited to the `meta_cache` slot: metadata blocks
-    are small but consulted on every read, so they belong in memory, and the
+    are small and every read consults them, so they belong in memory, and the
     [cache warmer](#cache_warmer_config) rebuilds the cache cheaply after a
     restart. Size it to hold the full live filter and index set so it never
     evicts.
@@ -248,8 +248,8 @@ The object store is tagged by `type`.
 
 On startup, the warmer discovers the time buckets that overlap the warm window
 and hands the SSTs backing them to SlateDB's cache manager, which loads each
-SST's filters and index — and, when `include_samples` is set, its sample data
-blocks — directly into the configured caches. Filters and indexes land in
+SST's filters and index (plus its sample data blocks when `include_samples` is
+set) directly into the configured caches. Filters and indexes land in
 `meta_cache`, data blocks in `block_cache`. The first queries after a restart
 then run against warm caches instead of paying object-store round trips.
 
@@ -269,8 +269,8 @@ cache_warmer:
 ```
 
 Match `warm_range` to the time range your dashboards and alerts query most.
-A warm window that exceeds cache capacity wastes work: some warmed blocks
-are evicted again before a query ever reads them.
+A warm window that exceeds cache capacity wastes work: the cache evicts some
+warmed blocks before a query ever reads them.
 
 ### `<buffer_consumer_config>`
 

--- a/timeseries/production.mdx
+++ b/timeseries/production.mdx
@@ -44,7 +44,7 @@ these files under `charts/opendata-timeseries/`.
 ```yaml values.yaml
 image:
   repository: ghcr.io/opendata-oss/timeseries
-  tag: "0.3.0"
+  tag: "0.4.0"
 
 port: 9090
 
@@ -284,11 +284,12 @@ from S3. For production workloads, use an SSD-backed StorageClass:
   issues many small random reads, and spinning disks will bottleneck performance.
 </Warning>
 
-### Block cache
+### Block and metadata caches
 
-On top of SlateDB's disk cache, Timeseries can keep decoded blocks in a
-hybrid memory-plus-disk block cache backed by [foyer](https://foyer.rs). Add
-it under `storage` in `prometheus.yaml`:
+On top of SlateDB's disk cache, Timeseries keeps SST blocks in two
+[foyer](https://foyer.rs)-backed caches: `block_cache` holds decoded data
+blocks, and `meta_cache` holds SST filters and indexes. Configure both under
+`storage` in `prometheus.yaml`:
 
 ```yaml prometheus.yaml
 storage:
@@ -305,27 +306,47 @@ storage:
     disk_path: /cache/foyer
     write_policy: WriteOnInsertion
     flushers: 4
+  meta_cache:
+    type: FoyerMemory
+    capacity: 4294967296           # 4 GiB
 ```
+
+<Warning>
+  Do not configure `block_cache` without `meta_cache`. Filters and indexes are
+  consulted on every read; if they are uncached, each read fetches them from
+  S3 again and query latency grows with SST count. In our testing, a query
+  that resolves in ~300ms with both caches took over three minutes with
+  `block_cache` alone.
+</Warning>
 
 Sizing guidance:
 
-- Set `memory_capacity` to roughly the recent working set (the last few hours
-  of bucket index and sample data).
+- Set the block cache's `memory_capacity` to roughly the recent working set
+  (the last few hours of sample data).
 - Point `disk_path` at the same SSD-backed PVC used by the disk cache; the
   two workloads coexist.
 - Keep `write_policy: WriteOnInsertion` so every cached block is also on disk.
   Restarts then hit the disk tier instead of re-reading from S3.
+- Size `meta_cache` to hold the full live filter and index set so it never
+  evicts. Metadata blocks are small relative to data: 4 GiB covers most
+  deployments. An in-memory cache is enough because the
+  [cache warmer](#cache-warmer) rebuilds it on restart.
 - Raise `flushers` if the `foyer_*` write-queue metrics show backpressure.
 
-See [`<block_cache_config>`](/timeseries/configuration#block_cache_config) for
-the full field reference.
+See [`<cache_config>`](/timeseries/configuration#cache_config) for the full
+field reference.
 
 ### Cache warmer
 
-On startup the server scans recent time bucket key ranges through the storage
-reader, which populates the block cache. Queries that hit in the first few
-seconds after a restart avoid a cold-cache penalty. This is on by default and
-covers the last 24 hours including sample data. To tune or disable it, see
+On startup the warmer discovers the time buckets in the warm window (default:
+the last 24 hours) and drives SlateDB's cache manager over the SSTs backing
+them, loading filters and indexes into `meta_cache` and sample data blocks
+into `block_cache`. Queries after a restart run against warm caches instead
+of paying object-store round trips — including on a fresh node, since the
+warmer reads from S3, not from any local state.
+
+The warmer is on by default and runs once at startup. To tune the window or
+disable it, see
 [`<cache_warmer_config>`](/timeseries/configuration#cache_warmer_config).
 
 ### Durable OTLP ingest

--- a/timeseries/production.mdx
+++ b/timeseries/production.mdx
@@ -312,10 +312,10 @@ storage:
 ```
 
 <Warning>
-  Do not configure `block_cache` without `meta_cache`. Filters and indexes are
-  consulted on every read; if they are uncached, each read fetches them from
-  S3 again and query latency grows with SST count. In our testing, a query
-  that resolves in ~300ms with both caches took over three minutes with
+  Do not configure `block_cache` without `meta_cache`. Every read consults
+  SST filters and indexes; without a cache for them, each read fetches them
+  from S3 again and query latency grows with SST count. In our testing, a
+  query that resolves in ~300ms with both caches took over three minutes with
   `block_cache` alone.
 </Warning>
 
@@ -342,8 +342,8 @@ On startup the warmer discovers the time buckets in the warm window (default:
 the last 24 hours) and drives SlateDB's cache manager over the SSTs backing
 them, loading filters and indexes into `meta_cache` and sample data blocks
 into `block_cache`. Queries after a restart run against warm caches instead
-of paying object-store round trips — including on a fresh node, since the
-warmer reads from S3, not from any local state.
+of paying object-store round trips. That holds on a fresh node too: the
+warmer reads from S3, not from local state.
 
 The warmer is on by default and runs once at startup. To tune the window or
 disable it, see


### PR DESCRIPTION
Updates the two pages that describe caching for production deployments:

**configuration.mdx**
- `<block_cache_config>` becomes `<cache_config>`, documenting both cache slots (`block_cache` for data blocks, `meta_cache` for filters/indexes/stats) and both foyer types (`FoyerHybrid`, `FoyerMemory` — the old text claimed only FoyerHybrid existed).
- `meta_cache` added to the SlateDb storage reference with a warning: `block_cache` without `meta_cache` leaves filters and indexes uncached, so reads re-fetch them from the object store and latency grows with SST count.
- `<cache_warmer_config>` rewritten: the warmer no longer scans key ranges through the reader; it drives SlateDB's cache manager over the SSTs backing recent buckets, loading filters/indexes into `meta_cache` and (optionally) data blocks into `block_cache`.

**production.mdx**
- "Block cache" section is now "Block and metadata caches" with `meta_cache` in the example config, sizing guidance, and the same warning (with the measured number: ~300ms with both caches vs 3+ minutes with `block_cache` alone).
- Cache warmer section rewritten to match the new mechanism.
- Helm chart image tag bumped to 0.4.0.

Background: we hit the missing-`meta_cache` failure mode on a fresh 0.4.0 deployment this week — a 108-series query issued ~12k S3 `get_range` calls and took 3+ minutes until `meta_cache` was configured, after which it dropped to ~300ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)